### PR TITLE
Fix error running tests with using python3

### DIFF
--- a/tests/simple_tests/tests.py
+++ b/tests/simple_tests/tests.py
@@ -231,7 +231,7 @@ def check_error():
                   "got '%s' instead" % (option, s))
 
       name = os.path.abspath(TMP_EXE_FILE)
-      open(name, "wb").write("")
+      open(name, "wb").write(b"")
       s = sub_check_error([name])
       if not (s.find(name) and (s.find("must be an x86 ELF executable") > 0)):
          raise Exception("Did not see expected error message for non-executable file")


### PR DESCRIPTION
Somewhat surprisingly, this is the only error encountered when running the tests using Python3(.8)

A particular version of Python to run the tests isn't mentioned anywhere as far as I can tell (or indeed mentioned as a requirement at all), but it seems a shame given the fix for it is so simple.

Given Python2 is now finally EoL, it wouldn't be a bad idea to clean it up a bit, things like opening files in "text mode". And the 3-space indentation. Who would even do such a thing? ;)