### PR TITLE
Enum DLLs if needed (fix #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Debug files
 *.dSYM/
+
+# Generated files
+src/generated*


### PR DESCRIPTION
If kernel32.dll hasn't been seen from the load events then attempt to find it by enumerating all the loaded DLLs and checking the names from GetModuleName. Fixes #3

I initially tried enumeration during the load event, but because of where it hooks the dll we are looking for is not yet in the list of enumerated dlls. As we are only looking for kernel32 it doesn't matter too much where we find it.

I've used `StrStrl` to do a case insensitive match, as in testing I was getting `KERNEL32.DLL` but I don't know if that is always the case.

L671-722 is esentially copy paste from the load event code, deduplicating this didn't seem worth it because of the scope of the variables written.

Feel free to modify if you like, but this is working for me 👍 